### PR TITLE
Set interpolate=False in the QuadraticModel initialisation.

### DIFF
--- a/citlalicue/citlalicue.py
+++ b/citlalicue/citlalicue.py
@@ -55,7 +55,7 @@ class light_curve:
             inc = np.arccos(b/a)
 
             #Let us use PyTransit to compute the transits
-            tm = QuadraticModel()
+            tm = QuadraticModel(interpolate=False)
             tm.set_data(self.time)
             flux = tm.evaluate(k=rp, ldc=ldc, t0=t0, p=p, a=a, i=inc)
             #Set attribute to the class


### PR DESCRIPTION
Hi Oscar,

Great to see you using PyTransit :) I made a very minor modification to the quadratic transit model initialisation by setting `ìnterpolate=False``. This turns off optimisations that are not required when you're not doing parameter inversion (where you may need to evaluate the model millions of times) and frees you from the need to set the radius ratio limits inside which the model is valid. These are set quite large by default, but this way you should be saved from any possible surprises if you want to model very small or very large planets.

Cheers,
Hannu